### PR TITLE
add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
  - docker pull elementary/docker:loki
  - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake . && make"
  - docker pull elementary/docker:loki-unstable
- - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki-unstable /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && make"
+ - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki-unstable /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake . && make"
 
 script:
  - echo BUILDS PASSED

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ services:
  - docker
 
 env:
- - DEPENDENCY_PACKAGES="appstream cmake intltool libgranite-dev libgtk-3-dev valac desktop-file-utils"
+ - DEPENDENCY_PACKAGES="cmake intltool libgranite-dev libgtk-3-dev valac"
 
 install:
  - docker pull elementary/docker:loki
- - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake . && env CTEST_OUTPUT_ON_FAILURE=true make all test"
+ - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake . && make"
  - docker pull elementary/docker:loki-unstable
- - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki-unstable /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake . && env CTEST_OUTPUT_ON_FAILURE=true make all test"
+ - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki-unstable /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && make"
 
 script:
  - echo BUILDS PASSED

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: generic
+
+services:
+ - docker
+
+env:
+ - DEPENDENCY_PACKAGES="appstream cmake intltool libgtk-3-dev valac desktop-file-utils"
+
+install:
+ - docker pull elementary/docker:loki
+ - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake . && env CTEST_OUTPUT_ON_FAILURE=true make all test"
+ - docker pull elementary/docker:loki-unstable
+ - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki-unstable /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake . && env CTEST_OUTPUT_ON_FAILURE=true make all test"
+
+script:
+ - echo BUILDS PASSED

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
  - docker
 
 env:
- - DEPENDENCY_PACKAGES="appstream cmake intltool libgtk-3-dev valac desktop-file-utils"
+ - DEPENDENCY_PACKAGES="appstream cmake intltool libgranite-dev libgtk-3-dev valac desktop-file-utils"
 
 install:
  - docker pull elementary/docker:loki


### PR DESCRIPTION
Adds a basic instance of Travis that just builds the project. This test just makes sure that it compiles.

In the future we can add more tests with cmake/Ctest/`make test`