### PR TITLE
travis: add libxml2-utils dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
  - docker
 
 env:
- - DEPENDENCY_PACKAGES="cmake desktop-file-utils intltool libgranite-dev libgtk-3-dev libxml2-dev valac"
+ - DEPENDENCY_PACKAGES="cmake desktop-file-utils intltool libgranite-dev libgtk-3-dev libxml2-dev libxml2-utils valac"
 
 install:
  - docker pull elementary/docker:loki


### PR DESCRIPTION
Travis logs have a warning:
```
XMLLINT not set and xmllint not found in path; skipping xml preprocessing.
```

`xmllint` is installed by `libxml2-utils`, which fixes the warning:
```
-- Checking for modules 'gtk+-3.0;granite;libxml-2.0'
--   Found gtk+-3.0, version 3.18.9
--   Found granite, version 0.4.0.1
--   Found libxml-2.0, version 2.9.3
```